### PR TITLE
JWT 발급 시 UserId, TagCode 포함하는 로직 추가

### DIFF
--- a/src/main/java/com/archiservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/archiservice/auth/service/impl/AuthServiceImpl.java
@@ -45,7 +45,7 @@ public class AuthServiceImpl implements AuthService {
 
         CustomUser customUser = new CustomUser(user);
         String accessToken = jwtUtil.generateAccessToken(customUser);
-        String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(customUser);
 
         redisService.saveRefreshToken(user.getEmail(), refreshToken);
 
@@ -63,9 +63,9 @@ public class AuthServiceImpl implements AuthService {
     public ApiResponse<RefreshResponseDto> refresh(String refreshTokenHeader) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        CustomUser customUser = (CustomUser) authentication.getPrincipal();
 
-        String newAccessToken = jwtUtil.generateAccessToken(userDetails);
+        String newAccessToken = jwtUtil.generateAccessToken(customUser);
 
         RefreshResponseDto responseDto = new RefreshResponseDto(email, newAccessToken);
 

--- a/src/main/java/com/archiservice/common/security/CustomUser.java
+++ b/src/main/java/com/archiservice/common/security/CustomUser.java
@@ -61,4 +61,8 @@ public class CustomUser implements UserDetails {
     public String getEmail() {
         return user.getEmail();
     }
+    
+    public Long getTagCode() {
+    	return user.getTagCode();
+    }
 }

--- a/src/main/java/com/archiservice/common/security/JwtUtil.java
+++ b/src/main/java/com/archiservice/common/security/JwtUtil.java
@@ -74,15 +74,18 @@ public class JwtUtil {
         return extractExpiration(token).before(new Date());
     }
 
-    public String generateAccessToken(UserDetails userDetails) {
+    public String generateAccessToken(CustomUser customUser) {
         Map<String, Object> claims = new HashMap<>();
-
-        return createToken(claims, userDetails.getUsername(), accessTokenExpiration);
+        claims.put("userId", customUser.getId());
+        claims.put("tagCode", customUser.getTagCode());
+        return createToken(claims, customUser.getUsername(), accessTokenExpiration);
     }
 
-    public String generateRefreshToken(String username) {
+    public String generateRefreshToken(CustomUser customUser) {
         Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, username, refreshTokenExpiration);
+        claims.put("userId", customUser.getId());
+        claims.put("tagCode", customUser.getTagCode());
+        return createToken(claims, customUser.getUsername(), refreshTokenExpiration);
     }
 
     private String createToken(Map<String, Object> claims, String subject, Long expiration) {


### PR DESCRIPTION
# 목적
- DB 조회 없이 JWT 에서 UserId, TagCode 를 바로 가져올 수 있게 함.

# 추가한 점
1. AccessToken 및 RefereshToken 발급 시 기존에 UserDetails 사용 -> CustomUser 사용
2. CustomUser의 `getId()`, `getTagCode()` 를 통해 JWT 생성 시 UserId, TagCode 정보 삽입