### PR TITLE
상품 등록, 계약 변경

### DIFF
--- a/src/main/java/com/archiservice/common/security/JwtUtil.java
+++ b/src/main/java/com/archiservice/common/security/JwtUtil.java
@@ -76,7 +76,6 @@ public class JwtUtil {
 
     public String generateAccessToken(UserDetails userDetails) {
         Map<String, Object> claims = new HashMap<>();
-       
 
         return createToken(claims, userDetails.getUsername(), accessTokenExpiration);
     }

--- a/src/main/java/com/archiservice/product/bundle/controller/ProductBundleController.java
+++ b/src/main/java/com/archiservice/product/bundle/controller/ProductBundleController.java
@@ -26,7 +26,7 @@ public class ProductBundleController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createBundle(@Valid @RequestBody CreateBundleRequestDto requestDto, @AuthenticationPrincipal CustomUser customUser) {
         bundleService.createBundle(requestDto, customUser);
-        return ResponseEntity.ok(ApiResponse.success("새로운 조합이 생성되었습니다.", null));
+        return ResponseEntity.ok(ApiResponse.success("선택하신 조합으로 예약이 갱신되었습니다.", null));
     }
 
     // ai 가 추천해준 조합이 최초의 조합이라면, bundle 테이블에 존재하지 않기 때문에 Session 에서 각 id 를 받아 각각 처리

--- a/src/main/java/com/archiservice/product/bundle/controller/ProductBundleController.java
+++ b/src/main/java/com/archiservice/product/bundle/controller/ProductBundleController.java
@@ -1,0 +1,49 @@
+package com.archiservice.product.bundle.controller;
+
+import com.archiservice.common.response.ApiResponse;
+import com.archiservice.common.security.CustomUser;
+import com.archiservice.product.bundle.dto.request.CreateBundleRequestDto;
+import com.archiservice.product.bundle.dto.response.BundleCombinationResponseDto;
+import com.archiservice.product.bundle.service.ProductBundleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/bundles")
+@RequiredArgsConstructor
+public class ProductBundleController {
+    private final ProductBundleService bundleService;
+
+    // 번들이 저장된다는 의미는 기존에 없었던 번들이라는 의미
+    // -> 사용자의 계약이 이루어졌다는 의미이기 때문에 @AuthenticationPrincipal CustomUser customUser 를 통해 사용자를 식별하고
+    // 해당 사용자 id 로 계약 테이블에 등록까지 수행하는 메서드
+    // 챗봇은 사용자 태그를 기반으로 3종을 개별 추천 ( 조합 자체를 추천하는 것이 아님! ), 사용자는 추천받은 각각의 후보 리스트에서 선택하여 최종 조합 생성
+    // -> 사용자가 최종 결정자이므로 계약이 이루어졌다는 의미를 가짐 : 챗봇이 추천해준 경우에도 최종 결정자는 사용자이므로 해당 메서드로 처리 가능
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createBundle(@Valid @RequestBody CreateBundleRequestDto requestDto, @AuthenticationPrincipal CustomUser customUser) {
+        bundleService.createBundle(requestDto, customUser);
+        return ResponseEntity.ok(ApiResponse.success("새로운 조합이 생성되었습니다.", null));
+    }
+
+    // ai 가 추천해준 조합이 최초의 조합이라면, bundle 테이블에 존재하지 않기 때문에 Session 에서 각 id 를 받아 각각 처리
+    @PostMapping("/{planId}/{vasId}/{couponId}")
+    public ResponseEntity<ApiResponse<BundleCombinationResponseDto>> getBundleByIds(@PathVariable Long planId, @PathVariable Long vasId, @PathVariable Long couponId) {
+        return ResponseEntity.ok(ApiResponse.success(bundleService.getBundleByIds(planId, vasId, couponId)));
+    }
+
+    @PutMapping("/{bundleId}/likeCount")
+    public ResponseEntity<ApiResponse<Void>> updateLikeOrDislikeCount(@PathVariable Long bundleId, @RequestParam boolean isLike) {
+
+        bundleService.updateLikeOrDislikeCount(bundleId, isLike);
+
+        if(isLike){
+            return ResponseEntity.ok(ApiResponse.success("좋아요", null));
+        } else{
+            return ResponseEntity.ok(ApiResponse.success("싫어요", null));
+        }
+    }
+}

--- a/src/main/java/com/archiservice/product/bundle/domain/ProductBundle.java
+++ b/src/main/java/com/archiservice/product/bundle/domain/ProductBundle.java
@@ -36,7 +36,7 @@ public class ProductBundle {
     private Coupon coupon;
 
     private long likeCount;
-    private long disLikeCount;
+    private long dislikeCount;
     private long tagCode;
 
     @CreatedDate

--- a/src/main/java/com/archiservice/product/bundle/domain/ProductBundle.java
+++ b/src/main/java/com/archiservice/product/bundle/domain/ProductBundle.java
@@ -4,6 +4,7 @@ import com.archiservice.product.coupon.domain.Coupon;
 import com.archiservice.product.plan.domain.Plan;
 import com.archiservice.product.vas.domain.Vas;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -21,7 +22,7 @@ public class ProductBundle {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_bundle_id")
-    private Long id;
+    private Long productBundleId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
@@ -43,4 +44,14 @@ public class ProductBundle {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @Builder
+    public ProductBundle(Plan plan, Vas vas, Coupon coupon, long tagCode) {
+        this.plan = plan;
+        this.vas = vas;
+        this.coupon = coupon;
+        this.likeCount = 0L;
+        this.dislikeCount = 0L;
+        this.tagCode = tagCode;
+    }
 }

--- a/src/main/java/com/archiservice/product/bundle/dto/request/CreateBundleRequestDto.java
+++ b/src/main/java/com/archiservice/product/bundle/dto/request/CreateBundleRequestDto.java
@@ -1,0 +1,11 @@
+package com.archiservice.product.bundle.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CreateBundleRequestDto {
+    private Long planId;
+    private Long vasId;
+    private Long couponId;
+    // 태그코드는 서비스로직에서 추출가능
+}

--- a/src/main/java/com/archiservice/product/bundle/dto/response/BundleCombinationResponseDto.java
+++ b/src/main/java/com/archiservice/product/bundle/dto/response/BundleCombinationResponseDto.java
@@ -1,0 +1,26 @@
+package com.archiservice.product.bundle.dto.response;
+
+import com.archiservice.product.coupon.dto.response.CouponDetailResponseDto;
+import com.archiservice.product.plan.dto.response.PlanDetailResponseDto;
+import com.archiservice.product.vas.dto.response.VasDetailResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BundleCombinationResponseDto {
+
+    BundleDetailResponseDto bundleDetail;
+    PlanDetailResponseDto planDetail;
+    VasDetailResponseDto vasDetail;
+    CouponDetailResponseDto couponDetail;
+
+    public static BundleCombinationResponseDto from(BundleDetailResponseDto bundleDto, PlanDetailResponseDto planDto, VasDetailResponseDto vasDto, CouponDetailResponseDto couponDto) {
+        return BundleCombinationResponseDto.builder()
+                .bundleDetail(bundleDto)
+                .planDetail(planDto)
+                .vasDetail(vasDto)
+                .couponDetail(couponDto)
+                .build();
+    }
+}

--- a/src/main/java/com/archiservice/product/bundle/dto/response/BundleDetailResponseDto.java
+++ b/src/main/java/com/archiservice/product/bundle/dto/response/BundleDetailResponseDto.java
@@ -1,0 +1,17 @@
+package com.archiservice.product.bundle.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BundleDetailResponseDto {
+    private Long bundleId;
+    private long likeCount;
+    private long dislikeCount;
+    private long tagCode;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/com/archiservice/product/bundle/repository/ProductBundleRepository.java
+++ b/src/main/java/com/archiservice/product/bundle/repository/ProductBundleRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 public interface ProductBundleRepository extends JpaRepository<ProductBundle, Long>{
 
     Optional<ProductBundle> findProductBundleByPlan_PlanIdAndVas_VasIdAndCoupon_CouponId(Long planId, Long vasId, Long couponId);
-    long findProductBundle_ProductBundleIdByPlanAndVasAndCoupon(Plan plan, Vas vas, Coupon coupon);
+    Optional<ProductBundle> findByPlanAndVasAndCoupon(Plan plan, Vas vas, Coupon coupon);
 
     @Modifying
     @Query("UPDATE ProductBundle pb SET pb.likeCount = pb.likeCount + 1 WHERE pb.productBundleId = :productBundleId")

--- a/src/main/java/com/archiservice/product/bundle/repository/ProductBundleRepository.java
+++ b/src/main/java/com/archiservice/product/bundle/repository/ProductBundleRepository.java
@@ -1,9 +1,30 @@
 package com.archiservice.product.bundle.repository;
 
 import com.archiservice.product.bundle.domain.ProductBundle;
+import com.archiservice.product.coupon.domain.Coupon;
+import com.archiservice.product.plan.domain.Plan;
+import com.archiservice.product.vas.domain.Vas;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ProductBundleRepository extends JpaRepository<ProductBundle, Long>{
+
+    Optional<ProductBundle> findProductBundleByPlan_PlanIdAndVas_VasIdAndCoupon_CouponId(Long planId, Long vasId, Long couponId);
+    long findProductBundle_ProductBundleIdByPlanAndVasAndCoupon(Plan plan, Vas vas, Coupon coupon);
+
+    @Modifying
+    @Query("UPDATE ProductBundle pb SET pb.likeCount = pb.likeCount + 1 WHERE pb.productBundleId = :productBundleId")
+    int incrementLikeCount(@Param("productBundleId") Long productBundleId);
+
+    @Modifying
+    @Query("UPDATE ProductBundle pb SET pb.dislikeCount = pb.dislikeCount + 1 WHERE pb.productBundleId = :productBundleId")
+    int incrementDislikeCount(@Param("productBundleId") Long productBundleId);
+
+    boolean existsByPlanAndVasAndCoupon(Plan plan, Vas vas, Coupon coupon);
 }

--- a/src/main/java/com/archiservice/product/bundle/service/ProductBundleService.java
+++ b/src/main/java/com/archiservice/product/bundle/service/ProductBundleService.java
@@ -1,0 +1,14 @@
+package com.archiservice.product.bundle.service;
+
+import com.archiservice.common.security.CustomUser;
+import com.archiservice.product.bundle.dto.request.CreateBundleRequestDto;
+import com.archiservice.product.bundle.dto.response.BundleCombinationResponseDto;
+
+public interface ProductBundleService {
+    void createBundle(CreateBundleRequestDto createBundleRequestDto, CustomUser customUser);
+
+    BundleCombinationResponseDto getBundleByIds(long planId, long vasId, long couponId);
+
+    void updateLikeOrDislikeCount(long bundleId, boolean isLike);
+
+}

--- a/src/main/java/com/archiservice/product/bundle/service/impl/ProductBundleServiceImpl.java
+++ b/src/main/java/com/archiservice/product/bundle/service/impl/ProductBundleServiceImpl.java
@@ -1,0 +1,152 @@
+package com.archiservice.product.bundle.service.impl;
+
+import com.archiservice.common.security.CustomUser;
+import com.archiservice.exception.BusinessException;
+import com.archiservice.exception.ErrorCode;
+import com.archiservice.exception.business.UserNotFoundException;
+import com.archiservice.product.bundle.domain.ProductBundle;
+import com.archiservice.product.bundle.dto.request.CreateBundleRequestDto;
+import com.archiservice.product.bundle.dto.response.BundleCombinationResponseDto;
+import com.archiservice.product.bundle.dto.response.BundleDetailResponseDto;
+import com.archiservice.product.bundle.repository.ProductBundleRepository;
+import com.archiservice.product.bundle.service.ProductBundleService;
+import com.archiservice.product.coupon.domain.Coupon;
+import com.archiservice.product.coupon.dto.response.CouponDetailResponseDto;
+import com.archiservice.product.coupon.repository.CouponRepository;
+import com.archiservice.product.coupon.service.CouponService;
+import com.archiservice.product.plan.domain.Plan;
+import com.archiservice.product.plan.dto.response.PlanDetailResponseDto;
+import com.archiservice.product.plan.repository.PlanRepository;
+import com.archiservice.product.plan.service.PlanService;
+import com.archiservice.product.vas.domain.Vas;
+import com.archiservice.product.vas.dto.response.VasDetailResponseDto;
+import com.archiservice.product.vas.repository.VasRepository;
+import com.archiservice.product.vas.service.VasService;
+import com.archiservice.user.domain.User;
+import com.archiservice.user.dto.request.ReservationRequestDto;
+import com.archiservice.user.repository.UserRepository;
+import com.archiservice.user.service.ContractService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductBundleServiceImpl implements ProductBundleService {
+    private final ProductBundleRepository productBundleRepository;
+    private final PlanRepository planRepository;
+    private final VasRepository vasRepository;
+    private final CouponRepository couponRepository;
+    private final PlanService planService;
+    private final VasService vasService;
+    private final CouponService couponService;
+    private final ContractService contractService;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void createBundle(CreateBundleRequestDto requestDto, CustomUser customUser) {
+        // 1. 번들에 추가하게되면, 사용자의 계약건에도 추가되어야함.
+        // 2. 조합이 기존에 존재하는 조합이라면 Bundle insert 건너뛰고, 사용자 계약건에 추가 ( 3번 )
+        // 3. 등록 가능기간, 불가능 기간 모두 예약건으로 계약 테이블에 추가
+        User user = userRepository.findById(customUser.getId())
+                .orElseThrow(() -> new UserNotFoundException());
+
+        Plan plan = planRepository.findById(requestDto.getPlanId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, "요금제를 찾을 수 없음"));
+
+        Vas vas = vasRepository.findById(requestDto.getVasId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, "부가서비스를 찾을 수 없음"));
+
+        Coupon coupon = couponRepository.findById(requestDto.getCouponId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, "라이프혜택을 찾을 수 없음"));
+
+        long finalPrice = plan.getPrice() + vas.getDiscountedPrice() + coupon.getPrice();
+
+        if(productBundleRepository.existsByPlanAndVasAndCoupon(plan, vas, coupon)) {
+
+            long bundleId = productBundleRepository.findProductBundle_ProductBundleIdByPlanAndVasAndCoupon(plan, vas, coupon);
+
+            ReservationRequestDto reservationRequestDto = ReservationRequestDto.builder()
+                    .bundleId(bundleId)
+                    .price(finalPrice)
+                    .build();
+
+            contractService.createContract(reservationRequestDto, user);
+
+        } else{
+            ProductBundle newProductBundle = ProductBundle.builder()
+                    .plan(plan)
+                    .vas(vas)
+                    .coupon(coupon)
+                    // TODO :  tagCode 는 추천 조합팀 완성되면 추가
+                    .build();
+
+            productBundleRepository.save(newProductBundle);
+
+            ReservationRequestDto reservationRequestDto = ReservationRequestDto.builder()
+                    .bundleId(newProductBundle.getProductBundleId())
+                    .price(finalPrice)
+                    .build();
+
+            contractService.createContract(reservationRequestDto, user);
+        }
+
+
+    }
+
+    @Override
+    public BundleCombinationResponseDto getBundleByIds(long planId, long vasId, long couponId) {
+        // 추천 조합 보기 - 조합 상세보기 : Session 에서 받아온 planId, vasId, couponId 로 상세 정보 구성
+        // 좋아요, 싫어요, 생성일, 업데이트일 : bundle 이 존재하면 가져오고, 없으면 0, 0, null, null 로 갖고와야함.
+        PlanDetailResponseDto planResponseDto = planService.getPlanDetail(planId);
+        VasDetailResponseDto vasDetailResponseDto = vasService.getVasDetail(vasId);
+        CouponDetailResponseDto couponDetailResponseDto = couponService.getCouponDetail(couponId);
+        BundleDetailResponseDto bundleDetailResponseDto = null;
+        Optional<ProductBundle> optBundle = productBundleRepository.findProductBundleByPlan_PlanIdAndVas_VasIdAndCoupon_CouponId(planId, vasId, couponId);
+
+        if(optBundle.isPresent()) {
+            ProductBundle bundle = optBundle.get();
+
+            bundleDetailResponseDto = BundleDetailResponseDto.builder()
+                    .bundleId(bundle.getProductBundleId())
+                    .likeCount(bundle.getLikeCount())
+                    .dislikeCount(bundle.getDislikeCount())
+                    .tagCode(bundle.getTagCode())
+                    .createAt(bundle.getCreatedAt())
+                    .updateAt(bundle.getUpdatedAt())
+                    .build();
+        }
+
+        BundleCombinationResponseDto bundleCombinationResponseDto = BundleCombinationResponseDto.builder()
+                .planDetail(planResponseDto)
+                .vasDetail(vasDetailResponseDto)
+                .couponDetail(couponDetailResponseDto)
+                .bundleDetail(bundleDetailResponseDto)
+                .build();
+
+        return bundleCombinationResponseDto;
+    }
+
+    @Override
+    @Transactional
+    public void updateLikeOrDislikeCount(long bundleId, boolean isLike) {
+        // 사용자는 좋아요 / 싫어요 로 반응, 무반응 시 해당 메서드는 실행되지 않음
+        // 사용자가 해당 조합에 이미 좋아요를 눌렀는지 체크필요 -> 현재 DB 구조로는 불가능 -> 좋아요 계속 누르면 계속 올라감, 프론트에서 한번 누르면 창 닫히도록 해야함.
+        // 번들이 무조건 테이블에 존재한다는 가정하에 이루어지는 로직 ( 사용자가 조합을 사용하다보면 며칠 뒤에 챗봇이 선제안으로 평가 물어보는 방식 )
+        int updatedRows;
+
+        if(isLike){
+            updatedRows = productBundleRepository.incrementLikeCount(bundleId);
+        }else{
+            updatedRows = productBundleRepository.incrementDislikeCount(bundleId);
+        }
+
+        if (updatedRows == 0) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+    }
+}

--- a/src/main/java/com/archiservice/user/controller/UserController.java
+++ b/src/main/java/com/archiservice/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.archiservice.user.dto.request.PasswordUpdateRequestDto;
 import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
 import com.archiservice.user.dto.response.ProfileResponseDto;
+import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.dto.response.TendencyResponseDto;
 import com.archiservice.user.service.ContractService;
 import com.archiservice.user.service.UserService;
@@ -61,7 +62,7 @@ public class UserController {
 
     @GetMapping("/current")
     public ResponseEntity<ApiResponse<List<ContractDetailResponseDto>>> getCurrentContract(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getContract(CURRENT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getContract(CURRENT, user)));
     }
 
     @GetMapping("/next/plans")
@@ -81,16 +82,21 @@ public class UserController {
 
     @GetMapping("/next")
     public ResponseEntity<ApiResponse<List<ContractDetailResponseDto>>> getNextContract(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getContract(NEXT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getContract(NEXT, user)));
     }
 
     @PutMapping("/next/cancel")
-    public ResponseEntity<ApiResponse> cancelNextReservation(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.cancelNextReservation(user));
+    public ResponseEntity<ApiResponse<ReservationResponseDto>> cancelNextContract(@AuthenticationPrincipal CustomUser user) {
+        return ResponseEntity.ok(ApiResponse.success(contractService.cancelNextContract(user)));
+    }
+
+    @PutMapping("/next/update")
+    public ResponseEntity<ApiResponse<ReservationResponseDto>> updateNextContract(@Valid @RequestBody ReservationRequestDto requestDto, @AuthenticationPrincipal CustomUser user) {
+        return ResponseEntity.ok(ApiResponse.success(contractService.updateNextContract(requestDto, user)));
     }
 
     @GetMapping("/history")
     public ResponseEntity<ApiResponse<List<ContractDetailResponseDto>>> getHistoryContract(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getContract(HISTORY, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getContract(HISTORY, user)));
     }
 }

--- a/src/main/java/com/archiservice/user/controller/UserController.java
+++ b/src/main/java/com/archiservice/user/controller/UserController.java
@@ -9,7 +9,6 @@ import com.archiservice.user.dto.request.PasswordUpdateRequestDto;
 import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
 import com.archiservice.user.dto.response.ProfileResponseDto;
-import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.dto.response.TendencyResponseDto;
 import com.archiservice.user.service.ContractService;
 import com.archiservice.user.service.UserService;
@@ -32,32 +31,33 @@ public class UserController {
 
     @GetMapping("/profile")
     public ResponseEntity<ApiResponse<ProfileResponseDto>> getUserProfile(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(userService.getUserProfile(user));
+        return ResponseEntity.ok(ApiResponse.success(userService.getUserProfile(user)));
     }
 
     @PutMapping("/password")
     public ResponseEntity<ApiResponse> updatePassword(@Valid @RequestBody PasswordUpdateRequestDto request, @AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(userService.updatePassword(request,user));
+        userService.updatePassword(request,user);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호 변경 성공"));
     }
 
     @GetMapping("/tendency")
     public ResponseEntity<ApiResponse<List<TendencyResponseDto>>> getUserTendency(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(userService.getUserTendency(user));
+        return ResponseEntity.ok(ApiResponse.success(userService.getUserTendency(user)));
     }
 
     @GetMapping("/current/plans")
     public ResponseEntity<ApiResponse<PlanDetailResponseDto>> getCurrentPlan(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getPlan(CURRENT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getPlan(CURRENT, user)));
     }
 
     @GetMapping("/current/vass")
     public ResponseEntity<ApiResponse<VasDetailResponseDto>> getCurrentService(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getVas(CURRENT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getVas(CURRENT, user)));
     }
 
     @GetMapping("/current/coupons")
     public ResponseEntity<ApiResponse<CouponDetailResponseDto>> getCurrentCoupon(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getCoupon(CURRENT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getCoupon(CURRENT, user)));
     }
 
     @GetMapping("/current")
@@ -67,17 +67,17 @@ public class UserController {
 
     @GetMapping("/next/plans")
     public ResponseEntity<ApiResponse<PlanDetailResponseDto>> getNextPlan(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getPlan(NEXT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getPlan(NEXT, user)));
     }
 
     @GetMapping("/next/vass")
     public ResponseEntity<ApiResponse<VasDetailResponseDto>> getNextService(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getVas(NEXT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getVas(NEXT, user)));
     }
 
     @GetMapping("/next/coupons")
     public ResponseEntity<ApiResponse<CouponDetailResponseDto>> getNextCoupon(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(contractService.getCoupon(NEXT, user));
+        return ResponseEntity.ok(ApiResponse.success(contractService.getCoupon(NEXT, user)));
     }
 
     @GetMapping("/next")
@@ -86,13 +86,15 @@ public class UserController {
     }
 
     @PutMapping("/next/cancel")
-    public ResponseEntity<ApiResponse<ReservationResponseDto>> cancelNextContract(@AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(ApiResponse.success(contractService.cancelNextContract(user)));
+    public ResponseEntity<ApiResponse<Void>> cancelNextContract(@AuthenticationPrincipal CustomUser user) {
+        contractService.cancelNextContract(user);
+        return ResponseEntity.ok(ApiResponse.success("예약 취소 성공",null));
     }
 
     @PutMapping("/next/update")
-    public ResponseEntity<ApiResponse<ReservationResponseDto>> updateNextContract(@Valid @RequestBody ReservationRequestDto requestDto, @AuthenticationPrincipal CustomUser user) {
-        return ResponseEntity.ok(ApiResponse.success(contractService.updateNextContract(requestDto, user)));
+    public ResponseEntity<ApiResponse<Void>> updateNextContract(@Valid @RequestBody ReservationRequestDto requestDto, @AuthenticationPrincipal CustomUser user) {
+        contractService.updateNextContract(requestDto, user);
+        return ResponseEntity.ok(ApiResponse.success("예약 갱신 성공", null));
     }
 
     @GetMapping("/history")

--- a/src/main/java/com/archiservice/user/controller/UserController.java
+++ b/src/main/java/com/archiservice/user/controller/UserController.java
@@ -84,7 +84,7 @@ public class UserController {
         return ResponseEntity.ok(contractService.getContract(NEXT, user));
     }
 
-    @PutMapping("/next")
+    @PutMapping("/next/cancel")
     public ResponseEntity<ApiResponse> cancelNextReservation(@AuthenticationPrincipal CustomUser user) {
         return ResponseEntity.ok(contractService.cancelNextReservation(user));
     }

--- a/src/main/java/com/archiservice/user/domain/Contract.java
+++ b/src/main/java/com/archiservice/user/domain/Contract.java
@@ -2,6 +2,7 @@ package com.archiservice.user.domain;
 
 import com.archiservice.product.bundle.domain.ProductBundle;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,5 +35,20 @@ public class Contract {
         this.paymentMethod = contract.paymentMethod;
         this.price = contract.price;
         this.productBundle = contract.productBundle;
+    }
+
+    @Builder
+    public Contract (ProductBundle productBundle, User user, String paymentMethod, Long price, LocalDateTime startDate, LocalDateTime endDate) {
+        this.productBundle = productBundle;
+        this.user = user;
+        this.paymentMethod = paymentMethod;
+        this.price = price;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void updateNextContract(ProductBundle bundle, Long price){
+        this.productBundle = bundle;
+        this.price = price;
     }
 }

--- a/src/main/java/com/archiservice/user/dto/request/CreateContractRequestDto.java
+++ b/src/main/java/com/archiservice/user/dto/request/CreateContractRequestDto.java
@@ -1,0 +1,10 @@
+package com.archiservice.user.dto.request;
+
+import com.archiservice.product.bundle.domain.ProductBundle;
+import lombok.Getter;
+
+@Getter
+public class CreateContractRequestDto {
+    private ProductBundle bundle;
+    private Long price;
+}

--- a/src/main/java/com/archiservice/user/dto/request/ReservationRequestDto.java
+++ b/src/main/java/com/archiservice/user/dto/request/ReservationRequestDto.java
@@ -1,6 +1,11 @@
 package com.archiservice.user.dto.request;
 
-// 바로 이어서 작업할 부분
-// 테스트 완료 후 정리
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class ReservationRequestDto {
+    private long bundleId;
+    private long price;
 }

--- a/src/main/java/com/archiservice/user/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/archiservice/user/dto/response/ReservationResponseDto.java
@@ -1,0 +1,4 @@
+package com.archiservice.user.dto.response;
+
+public class ReservationResponseDto {
+}

--- a/src/main/java/com/archiservice/user/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/archiservice/user/dto/response/ReservationResponseDto.java
@@ -1,4 +1,0 @@
-package com.archiservice.user.dto.response;
-
-public class ReservationResponseDto {
-}

--- a/src/main/java/com/archiservice/user/repository/ContractRepository.java
+++ b/src/main/java/com/archiservice/user/repository/ContractRepository.java
@@ -38,4 +38,5 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
     Optional<Long> findCouponIdByOffset(@Param("userId") Long userId, @Param("offset") int offset);
 
     List<Contract> findTop2ByUserOrderByIdDesc(User user);
+    Contract findTop1ByUserOrderByIdDesc(User user);
 }

--- a/src/main/java/com/archiservice/user/service/ContractService.java
+++ b/src/main/java/com/archiservice/user/service/ContractService.java
@@ -24,4 +24,5 @@ public interface ContractService {
     ReservationResponseDto cancelNextContract(CustomUser customUser); // 예약 취소 버튼을 누르면 예약을 이번달과 같게 하는 서비스
     ReservationResponseDto updateNextContract(ReservationRequestDto requestDto, CustomUser customUser); // 예약 변경 버튼을 누르면 예약을 해당 조합으로 바꾸는 서비스
 
+    void determineContractAction(ReservationRequestDto requestDto, CustomUser customUser);
 }

--- a/src/main/java/com/archiservice/user/service/ContractService.java
+++ b/src/main/java/com/archiservice/user/service/ContractService.java
@@ -5,16 +5,23 @@ import com.archiservice.common.security.CustomUser;
 import com.archiservice.product.coupon.dto.response.CouponDetailResponseDto;
 import com.archiservice.product.plan.dto.response.PlanDetailResponseDto;
 import com.archiservice.product.vas.dto.response.VasDetailResponseDto;
+import com.archiservice.user.domain.User;
+import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
+import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.enums.Period;
 
 import java.util.List;
 
 public interface ContractService {
+    void createContract(ReservationRequestDto requestDto, User user);
+
     ApiResponse<PlanDetailResponseDto> getPlan(Period period, CustomUser customUser);
     ApiResponse<VasDetailResponseDto> getVas(Period period, CustomUser customUser);
     ApiResponse<CouponDetailResponseDto> getCoupon(Period period, CustomUser customUser);
-    ApiResponse<List<ContractDetailResponseDto>> getContract (Period period, CustomUser customUser);
+    List<ContractDetailResponseDto> getContract (Period period, CustomUser customUser);
 
-    ApiResponse cancelNextReservation(CustomUser customUser);
+    ReservationResponseDto cancelNextContract(CustomUser customUser); // 예약 취소 버튼을 누르면 예약을 이번달과 같게 하는 서비스
+    ReservationResponseDto updateNextContract(ReservationRequestDto requestDto, CustomUser customUser); // 예약 변경 버튼을 누르면 예약을 해당 조합으로 바꾸는 서비스
+
 }

--- a/src/main/java/com/archiservice/user/service/ContractService.java
+++ b/src/main/java/com/archiservice/user/service/ContractService.java
@@ -1,6 +1,5 @@
 package com.archiservice.user.service;
 
-import com.archiservice.common.response.ApiResponse;
 import com.archiservice.common.security.CustomUser;
 import com.archiservice.product.coupon.dto.response.CouponDetailResponseDto;
 import com.archiservice.product.plan.dto.response.PlanDetailResponseDto;
@@ -8,7 +7,6 @@ import com.archiservice.product.vas.dto.response.VasDetailResponseDto;
 import com.archiservice.user.domain.User;
 import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
-import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.enums.Period;
 
 import java.util.List;
@@ -16,13 +14,13 @@ import java.util.List;
 public interface ContractService {
     void createContract(ReservationRequestDto requestDto, User user);
 
-    ApiResponse<PlanDetailResponseDto> getPlan(Period period, CustomUser customUser);
-    ApiResponse<VasDetailResponseDto> getVas(Period period, CustomUser customUser);
-    ApiResponse<CouponDetailResponseDto> getCoupon(Period period, CustomUser customUser);
+    PlanDetailResponseDto getPlan(Period period, CustomUser customUser);
+    VasDetailResponseDto getVas(Period period, CustomUser customUser);
+    CouponDetailResponseDto getCoupon(Period period, CustomUser customUser);
     List<ContractDetailResponseDto> getContract (Period period, CustomUser customUser);
 
-    ReservationResponseDto cancelNextContract(CustomUser customUser); // 예약 취소 버튼을 누르면 예약을 이번달과 같게 하는 서비스
-    ReservationResponseDto updateNextContract(ReservationRequestDto requestDto, CustomUser customUser); // 예약 변경 버튼을 누르면 예약을 해당 조합으로 바꾸는 서비스
+    void cancelNextContract(CustomUser customUser); // 예약 취소 버튼을 누르면 예약을 이번달과 같게 하는 서비스
+    void updateNextContract(ReservationRequestDto requestDto, CustomUser customUser); // 예약 변경 버튼을 누르면 예약을 해당 조합으로 바꾸는 서비스
 
     void determineContractAction(ReservationRequestDto requestDto, CustomUser customUser);
 }

--- a/src/main/java/com/archiservice/user/service/UserService.java
+++ b/src/main/java/com/archiservice/user/service/UserService.java
@@ -9,7 +9,7 @@ import com.archiservice.user.dto.response.TendencyResponseDto;
 import java.util.List;
 
 public interface UserService {
-    ApiResponse<ProfileResponseDto> getUserProfile(CustomUser user);
-    ApiResponse updatePassword(PasswordUpdateRequestDto request, CustomUser user);
-    ApiResponse<List<TendencyResponseDto>> getUserTendency(CustomUser user);
+    ProfileResponseDto getUserProfile(CustomUser user);
+    void updatePassword(PasswordUpdateRequestDto request, CustomUser user);
+    List<TendencyResponseDto> getUserTendency(CustomUser user);
 }

--- a/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
@@ -5,6 +5,8 @@ import com.archiservice.common.security.CustomUser;
 import com.archiservice.exception.BusinessException;
 import com.archiservice.exception.ErrorCode;
 import com.archiservice.exception.business.UserNotFoundException;
+import com.archiservice.product.bundle.domain.ProductBundle;
+import com.archiservice.product.bundle.repository.ProductBundleRepository;
 import com.archiservice.product.coupon.dto.response.CouponDetailResponseDto;
 import com.archiservice.product.coupon.service.CouponService;
 import com.archiservice.product.plan.dto.response.PlanDetailResponseDto;
@@ -13,7 +15,9 @@ import com.archiservice.product.vas.dto.response.VasDetailResponseDto;
 import com.archiservice.product.vas.service.VasService;
 import com.archiservice.user.domain.Contract;
 import com.archiservice.user.domain.User;
+import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
+import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.enums.Period;
 import com.archiservice.user.repository.ContractRepository;
 import com.archiservice.user.repository.UserRepository;
@@ -34,6 +38,30 @@ public class ContractServiceImpl implements ContractService {
     private final PlanService planService;
     private final VasService vasService;
     private final CouponService couponService;
+    private final ProductBundleRepository productBundleRepository;
+
+    @Override
+    @Transactional
+    // Issue : Scheduling Batch, User 를 받는 방식 고민 (시스템이 자동 추가해야하므로, 유저가 직접 추가하는 방식이 아님)
+    public void createContract(ReservationRequestDto requestDto, User user) {
+        // 다음달 계약이 생성되는 시점에는 가장 최근건이 이번달 계약임. -> top1 사용
+
+        ProductBundle bundle = productBundleRepository.findById(requestDto.getBundleId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, "조합 정보가 존재하지 않음"));
+
+        Contract curContract = contractRepository.findTop1ByUserOrderByIdDesc(user);
+
+        Contract newContract = Contract.builder()
+                .productBundle(bundle)
+                .user(user)
+                .paymentMethod(curContract.getPaymentMethod())
+                .price(requestDto.getPrice())
+                .startDate(curContract.getEndDate())
+                .endDate(curContract.getEndDate().plusMonths(1))
+                .build();
+
+        contractRepository.save(newContract);
+    }
 
     @Override
     public ApiResponse<PlanDetailResponseDto> getPlan(Period period, CustomUser customUser) {
@@ -75,18 +103,18 @@ public class ContractServiceImpl implements ContractService {
     }
 
     @Override
-    public ApiResponse<List<ContractDetailResponseDto>> getContract(Period period, CustomUser customUser) {
+    public List<ContractDetailResponseDto> getContract(Period period, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
         List<ContractDetailResponseDto> contractDetailResponseListDto = contractCustomRepository.findContractByOffset(user, period);
 
-        return ApiResponse.success(contractDetailResponseListDto);
+        return contractDetailResponseListDto;
     }
 
     @Override
     @Transactional
-    public ApiResponse cancelNextReservation(CustomUser customUser) {
+    public ReservationResponseDto cancelNextContract(CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -96,6 +124,21 @@ public class ContractServiceImpl implements ContractService {
 
         newContract.copyFrom(curContract);
 
-        return ApiResponse.success(null);
+        return null; // ReservationResponseDto 여기에 뭘 담아야하는가
+    }
+
+    @Override
+    @Transactional
+    public ReservationResponseDto updateNextContract(ReservationRequestDto requestDto, CustomUser customUser) {
+        User user = userRepository.findById(customUser.getId())
+                .orElseThrow(() -> new UserNotFoundException());
+
+        ProductBundle bundle = productBundleRepository.findById(requestDto.getBundleId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND, "조합 정보가 존재하지 않음"));
+
+        Contract nextContract = contractRepository.findTop1ByUserOrderByIdDesc(user);
+        nextContract.updateNextContract(bundle, requestDto.getPrice());
+
+        return null;
     }
 }

--- a/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
@@ -42,7 +42,7 @@ public class ContractServiceImpl implements ContractService {
 
     @Override
     @Transactional
-    // Issue : Scheduling Batch, User 를 받는 방식 고민 (시스템이 자동 추가해야하므로, 유저가 직접 추가하는 방식이 아님)
+    // Issue : Scheduling Batch, User 를 받는 방식 고민 (시스템이 자동 추가해야하므로, 유저가 직접 추가하는 방식이 아님 -> 현재 컨트롤러가 아닌, 신규 번들 생성 이후 연계로 실행되는 형태)
     public void createContract(ReservationRequestDto requestDto, User user) {
         // 다음달 계약이 생성되는 시점에는 가장 최근건이 이번달 계약임. -> top1 사용
 

--- a/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
@@ -27,6 +27,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -140,5 +141,21 @@ public class ContractServiceImpl implements ContractService {
         nextContract.updateNextContract(bundle, requestDto.getPrice());
 
         return null;
+    }
+
+    @Override
+    public void determineContractAction(ReservationRequestDto requestDto, CustomUser customUser) {
+        User user = userRepository.findById(customUser.getId())
+                .orElseThrow(() -> new UserNotFoundException());
+
+        Contract recentContract = contractRepository.findTop1ByUserOrderByIdDesc(user);
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = recentContract.getEndDate().toLocalDate();
+
+        if(today.equals(endDate)) {
+            createContract(requestDto, user);
+        } else {
+            updateNextContract(requestDto, customUser);
+        }
     }
 }

--- a/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/archiservice/user/service/impl/ContractServiceImpl.java
@@ -17,7 +17,6 @@ import com.archiservice.user.domain.Contract;
 import com.archiservice.user.domain.User;
 import com.archiservice.user.dto.request.ReservationRequestDto;
 import com.archiservice.user.dto.response.ContractDetailResponseDto;
-import com.archiservice.user.dto.response.ReservationResponseDto;
 import com.archiservice.user.enums.Period;
 import com.archiservice.user.repository.ContractRepository;
 import com.archiservice.user.repository.UserRepository;
@@ -65,7 +64,7 @@ public class ContractServiceImpl implements ContractService {
     }
 
     @Override
-    public ApiResponse<PlanDetailResponseDto> getPlan(Period period, CustomUser customUser) {
+    public PlanDetailResponseDto getPlan(Period period, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -74,11 +73,11 @@ public class ContractServiceImpl implements ContractService {
 
         PlanDetailResponseDto planDetailResponseDto = planService.getPlanDetail(planId);
 
-        return ApiResponse.success(planDetailResponseDto);
+        return planDetailResponseDto;
     }
 
     @Override
-    public ApiResponse<VasDetailResponseDto> getVas(Period period, CustomUser customUser) {
+    public VasDetailResponseDto getVas(Period period, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -87,11 +86,11 @@ public class ContractServiceImpl implements ContractService {
 
         VasDetailResponseDto vasDetailResponseDto = vasService.getVasDetail(vasId);
 
-        return ApiResponse.success(vasDetailResponseDto);
+        return vasDetailResponseDto;
     }
 
     @Override
-    public ApiResponse<CouponDetailResponseDto> getCoupon(Period period, CustomUser customUser) {
+    public CouponDetailResponseDto getCoupon(Period period, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -100,7 +99,7 @@ public class ContractServiceImpl implements ContractService {
 
         CouponDetailResponseDto couponDetailResponseDto = couponService.getCouponDetail(couponId);
 
-        return ApiResponse.success(couponDetailResponseDto);
+        return couponDetailResponseDto;
     }
 
     @Override
@@ -115,7 +114,7 @@ public class ContractServiceImpl implements ContractService {
 
     @Override
     @Transactional
-    public ReservationResponseDto cancelNextContract(CustomUser customUser) {
+    public void cancelNextContract(CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -124,13 +123,11 @@ public class ContractServiceImpl implements ContractService {
         Contract curContract = contractList.get(1);
 
         newContract.copyFrom(curContract);
-
-        return null; // ReservationResponseDto 여기에 뭘 담아야하는가
     }
 
     @Override
     @Transactional
-    public ReservationResponseDto updateNextContract(ReservationRequestDto requestDto, CustomUser customUser) {
+    public void updateNextContract(ReservationRequestDto requestDto, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException());
 
@@ -139,8 +136,6 @@ public class ContractServiceImpl implements ContractService {
 
         Contract nextContract = contractRepository.findTop1ByUserOrderByIdDesc(user);
         nextContract.updateNextContract(bundle, requestDto.getPrice());
-
-        return null;
     }
 
     @Override

--- a/src/main/java/com/archiservice/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/archiservice/user/service/impl/UserServiceImpl.java
@@ -27,17 +27,17 @@ public class UserServiceImpl implements UserService {
     private final TagMetaService tagMetaService;
 
     @Override
-    public ApiResponse<ProfileResponseDto> getUserProfile(CustomUser customUser) {
+    public ProfileResponseDto getUserProfile(CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException("올바른 사용자 정보를 가져오지 못했습니다."));
 
         ProfileResponseDto profileResponseDto = ProfileResponseDto.from(user);
 
-        return ApiResponse.success(profileResponseDto);
+        return profileResponseDto;
     }
 
     @Override
-    public ApiResponse updatePassword(PasswordUpdateRequestDto request, CustomUser customUser) {
+    public void updatePassword(PasswordUpdateRequestDto request, CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException("올바른 사용자 정보를 가져오지 못했습니다."));
 
@@ -47,12 +47,10 @@ public class UserServiceImpl implements UserService {
 
         user.setPassword(passwordEncoder.encode(request.getNewPassword()));
         userRepository.save(user);
-
-        return ApiResponse.success(null);
     }
 
     @Override
-    public ApiResponse<List<TendencyResponseDto>> getUserTendency(CustomUser customUser) {
+    public List<TendencyResponseDto> getUserTendency(CustomUser customUser) {
         User user = userRepository.findById(customUser.getId())
                 .orElseThrow(() -> new UserNotFoundException("올바른 사용자 정보를 가져오지 못했습니다."));
 
@@ -69,6 +67,6 @@ public class UserServiceImpl implements UserService {
             tendencies.add(tendencyResponseDto);
         }
 
-        return ApiResponse.success(tendencies);
+        return tendencies;
     }
 }


### PR DESCRIPTION
## FR-004
* 기능번호 없음 : 예약되어 있는 구독을 변경한다.
* 취소와 다르게, 예약되어 있는 구독을 원하는 구독으로 변경한다.

## FR-012
* FR-012-01 : 전체 요금제 목록에서 원하는 요금제를 선택해서 조합에 추가한다.
* FR-012-02 : 전체 부가서비스 목록에서 원하는 부가서비스를 선택해서 조합에 추가한다.
* FR-012-03 : 전체 라이프 혜택 목록에서 원하는 라이프 혜택을 선택해서 조합에 추가한다.
* FR-012-05 : 새로운 조합을 등록한다 -> 예약 정보가 갱신된다. 
* ※ 새로운 조합을 등록하면 오늘 날짜와 사용자의 가장 최근 계약건 종료일을 비교하여 새로운 계약을 생성하거나, 기존 계약을 갱신하는 흐름으로 구현
* 기능번호 없음 : 사용자가 방금 조합한, 혹은 이미 존재하던 조합의 상세 보기 (요금제, 부가서비스, 쿠폰)
![image](https://github.com/user-attachments/assets/a89299c3-0bc8-4bfa-9a8a-f523bfd6b64b)
※ 해당 화면에서 좋아요, 싫어요, 생성일, 업데이트일까지 보여줄 수 있음

## 리팩토링
* 기존 서비스들이 모두 ApiResponse<Type> 형식으로 리턴해줘서 다른 클래스에서는 해당 서비스를 쓰기 까다로웠다.
* 이 문제를 해결하기 위해 Type 형식으로 리턴해주는 방식으로 리팩토링