### PR TITLE
[JWT/성향] 성향 테스트 이후 로그인 상태인 유저의 토큰 정보(성향 부분) 업데이트 로직 (#46 이슈)

### DIFF
--- a/src/main/java/com/archiservice/survey/dto/response/QuestionResponseDto.java
+++ b/src/main/java/com/archiservice/survey/dto/response/QuestionResponseDto.java
@@ -1,6 +1,5 @@
 package com.archiservice.survey.dto.response;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.archiservice.survey.domain.Question;
@@ -18,6 +17,7 @@ public class QuestionResponseDto {
 	String questionText;
 	int order;
 	List<OptionResponseDto> options;
+	List<String> tagCodes;
 	
 	public static QuestionResponseDto from(Question question) {
 		return QuestionResponseDto.builder()

--- a/src/main/java/com/archiservice/survey/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/com/archiservice/survey/service/impl/SurveyServiceImpl.java
@@ -54,8 +54,7 @@ public class SurveyServiceImpl implements SurveyService{
 		if (nextQuestionId == null) {
 			// 성향 테스트 종료 지점
 			List<String> tagCodes = metaService.extractTagsFromCode(tagCodeSum);
-			session.setAttribute("tagCodes", tagCodes);
-			return ApiResponse.success(new QuestionResponseDto("성향 테스트 종료", 0, List.of()));
+			return ApiResponse.success(new QuestionResponseDto("성향 테스트 종료", 0, List.of(), tagCodes));
 			
 		}else {
 			question = questionRepository.findById(nextQuestionId)
@@ -84,10 +83,11 @@ public class SurveyServiceImpl implements SurveyService{
 		
 		// JWT tagCode 정보 삽입
 		Map<String, Object> claims = new HashMap<>();
+		claims.put("userId", userId);
 		claims.put("tagCdoe", tagCode);
 		String tagCodeAccessToken = jwtUtil.generateCustomToken(claims, user.getEmail());
 		
-		session.removeAttribute("tagCodes");
+		session.removeAttribute("tagCodeSum");
 		return ApiResponse.success(tagCodeAccessToken);
 	}
 	

--- a/src/main/resources/static/surveyTest.html
+++ b/src/main/resources/static/surveyTest.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>survey</title>
+</head>
+<body>
+	<div id="LoginDiv">
+		<h2>로그인</h2>
+	    <form id="loginForm">
+	        <label for="email">이메일:</label>
+	        <input type="email" id="email" name="email" value="user1@test.com" required ><br><br>
+	
+	        <label for="password">비밀번호:</label>
+	        <input type="password" id="password" name="password" value="pw1" required><br><br>
+	
+	        <button type="submit">로그인</button>
+	    </form>
+	</div>
+	
+	<div id="SurveyForm" style="display:none;">
+		<button type="button" id="startSurveyBtn">설문 시작</button>
+		<div id="questionBox"></div>
+		<div id="optionBox"></div>
+		<div id="resultBox" style="display:none;">
+	        <button id="submitResultBtn">설문결과등록하기</button>
+	    </div>
+	</div>
+	
+	<script>
+        const form = document.getElementById('loginForm');
+        form.addEventListener('submit', async function (e) {
+            e.preventDefault();
+
+            const email = document.getElementById('email').value;
+            const password = document.getElementById('password').value;
+
+            const response = await fetch('/auth/login', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ email, password })
+            });
+
+            if (response.ok) {
+            	const result = await response.json();
+            	const accessToken = result.data.accessToken;
+            	
+            	localStorage.setItem('accessToken', accessToken);
+            	
+            	document.getElementById('LoginDiv').style.display = "none";
+            	document.getElementById('SurveyForm').style.display = "block";
+            } else {
+                const error = await response.json();
+                console.error("로그인 실패:", error.message || "알 수 없는 오류");
+            }
+        });
+        
+        
+        document.getElementById('startSurveyBtn').addEventListener('click', () => loadQuestion(1));
+
+        async function loadQuestion(nextQuestionId, tagCode = null) {
+        	document.getElementById('startSurveyBtn').style.display = "none";
+        	let url = '/surveys/questions';
+        	if (nextQuestionId !== null) {
+        	    url += `?nextQuestionId=${nextQuestionId}`;
+        	    if (tagCode !== null) url += `&tagCode=${tagCode}`;
+        	}
+        	
+        	
+            const response = await fetchWithAuth(url, {
+            	method : 'GET',
+            });
+
+            if (response.ok) {
+            	
+                const result = await response.json();
+                const data = result.data;
+                console.log(data);
+                
+                if (nextQuestionId === null) {
+                    // 설문 종료
+                    document.getElementById('questionBox').style.display = 'none';
+                    document.getElementById('optionBox').style.display = 'none';
+                    document.getElementById('resultBox').style.display = 'block';
+                    alert("당신의 성향 태그: \n\n" + data.tagCodes.join(', '));
+                    return;
+                }
+
+                // 질문 표시
+                document.getElementById('questionBox').style.display = 'block';
+                document.getElementById('questionBox').innerText = `질문 ${data.order}: ${data.questionText}`;
+
+                // 옵션 버튼 표시
+                const optionBox = document.getElementById('optionBox');
+                optionBox.style.display = 'block';
+                optionBox.innerHTML = ''; // 초기화
+
+                data.options.forEach(opt => {
+                    const btn = document.createElement('button');
+                    btn.innerText = opt.optionText;
+                    btn.addEventListener('click', () => loadQuestion(opt.nextQustionId, opt.tagCode));
+                    optionBox.appendChild(btn);
+                });
+            } else {
+                const error = await response.json();
+                console.error("질문 요청 실패:", error.message || "알 수 없는 오류");
+            }
+        }
+
+        
+        document.getElementById('submitResultBtn').addEventListener('click', async function () {
+
+            const response = await fetchWithAuth('/surveys/save', {
+                method: 'POST',
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                const newToken = result.data;  // tagCode가 포함된 accessToken
+                alert(`설문 결과 저장 완료! JWT에 포함된 tagCode 토큰:\n\n${newToken}`);
+                localStorage.setItem('accessToken', newToken);
+            } else {
+                const error = await response.json();
+                console.error("설문 결과 저장 실패:", error.message || "알 수 없는 오류");
+                alert("설문 결과 저장 중 오류가 발생했습니다.");
+            }
+        });
+
+        
+        
+        
+        
+        async function fetchWithAuth(url, options = {}) {
+            const token = localStorage.getItem('accessToken');
+            options.headers = {
+                ...options.headers,
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            };
+
+            let response = await fetch(url, options);
+
+            if (response.status === 401) {
+                // accessToken 만료, refresh 요청 (refreshToken은 HttpOnly 쿠키에 있으므로 헤더 필요 없음)
+                const refreshResponse = await fetch('/auth/refresh', {
+                    method: 'POST',
+                    credentials: 'include'  // 쿠키 포함을 명시
+                });
+
+                if (refreshResponse.ok) {
+                    const data = await refreshResponse.json();
+                    const newAccessToken = data.data.accessToken;
+                    localStorage.setItem('accessToken', newAccessToken);
+
+                    // accessToken 갱신 후 재요청
+                    options.headers['Authorization'] = `Bearer ${newAccessToken}`;
+                    response = await fetch(url, options);
+                } else {
+                    alert("로그인 세션이 만료되었습니다. 다시 로그인해주세요.");
+                    location.reload();
+                }
+            }
+
+            return response;
+        }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
# 목적
성향테스트를 완료한다면 user 테이블의 tageCode 필드가 업데이트된다.
이에 따라 현재 JWT에 담긴 성향태그도 같이 업데이트하는 로직을 추가한다.

# 흐름
1. `/survey/save` api 호출
2. session 에 담긴 `tagCodeSum` (성향태그 8종의 정보) 와 `userId` 를 담은 새 JWT `tagCodeAccessToken` 발급
3. session remove 진행 (재활용 방지)
4. ApiResponse 에 `tagCodeAccessToken` 를 담아서 클라이언트에게 반환

# 고려할점
- refresh 발생 시 성향태그가 현재 DB에 담긴 것으로 업데이트 된다면 위 로직 없이 refresh만 진행해도 되는건가?
