### PR TITLE
[Fix] JWT userEmail 삭제

### DIFF
--- a/src/main/java/com/archiservice/auth/dto/response/LogoutResponseDto.java
+++ b/src/main/java/com/archiservice/auth/dto/response/LogoutResponseDto.java
@@ -4,5 +4,5 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class LogoutResponseDto {
-    private String email;
+    private Long userId;
 }

--- a/src/main/java/com/archiservice/auth/dto/response/RefreshResponseDto.java
+++ b/src/main/java/com/archiservice/auth/dto/response/RefreshResponseDto.java
@@ -4,6 +4,6 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class RefreshResponseDto {
-    private String email;
+    private Long userId;
     private String newAccessToken;
 }

--- a/src/main/java/com/archiservice/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/archiservice/auth/service/impl/AuthServiceImpl.java
@@ -47,7 +47,7 @@ public class AuthServiceImpl implements AuthService {
         String accessToken = jwtUtil.generateAccessToken(customUser);
         String refreshToken = jwtUtil.generateRefreshToken(customUser);
 
-        refreshTokenService.saveRefreshToken(user.getEmail(), refreshToken);
+        refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken);
 
         Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setHttpOnly(true);
@@ -62,12 +62,12 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public ApiResponse<RefreshResponseDto> refresh(String refreshTokenHeader) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String email = authentication.getName();
         CustomUser customUser = (CustomUser) authentication.getPrincipal();
-
+        
+        Long userId = customUser.getId();
         String newAccessToken = jwtUtil.generateAccessToken(customUser);
 
-        RefreshResponseDto responseDto = new RefreshResponseDto(email, newAccessToken);
+        RefreshResponseDto responseDto = new RefreshResponseDto(userId, newAccessToken);
 
         return ApiResponse.success("재발급 완료", responseDto);
     }
@@ -80,11 +80,11 @@ public class AuthServiceImpl implements AuthService {
         }
 
         String accessToken = accessTokenHeader.replace("Bearer ", "");
-        String email = jwtUtil.extractEmail(accessToken);
+        Long userId = jwtUtil.extractUserId(accessToken);
 
-        refreshTokenService.deleteRefreshToken(email);
+        refreshTokenService.deleteRefreshToken(userId);
 
-        LogoutResponseDto dto = new LogoutResponseDto(email);
+        LogoutResponseDto dto = new LogoutResponseDto(userId);
 
         return ApiResponse.success("로그아웃이 완료되었습니다", dto);
 

--- a/src/main/java/com/archiservice/common/jwt/RefreshTokenService.java
+++ b/src/main/java/com/archiservice/common/jwt/RefreshTokenService.java
@@ -20,52 +20,52 @@ public class RefreshTokenService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
 
-    public void saveRefreshToken(String email, String refreshToken) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
         Duration expiration = Duration.ofMillis(refreshTokenExpiration);
 
         stringRedisTemplate.opsForValue().set(key, refreshToken, expiration);
-        log.info("Refresh token saved for user: {}", email);
+        log.info("Refresh token saved for user: {}", userId);
     }
 
-    public String getRefreshToken(String email) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public String getRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
         String token = stringRedisTemplate.opsForValue().get(key);
 
         if (token != null) {
-            log.info("Refresh token found for user: {}", email);
+            log.info("Refresh token found for user: {}", userId);
         } else {
-            log.info("No refresh token found for user: {}", email);
+            log.info("No refresh token found for user: {}", userId);
         }
 
         return token;
     }
 
-    public void deleteRefreshToken(String email) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public void deleteRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
         Boolean deleted = stringRedisTemplate.delete(key);
 
         if (Boolean.TRUE.equals(deleted)) {
-            log.info("Refresh token deleted for user: {}", email);
+            log.info("Refresh token deleted for user: {}", userId);
         } else {
-            log.warn("No refresh token to delete for user: {}", email);
+            log.warn("No refresh token to delete for user: {}", userId);
         }
     }
 
-    public boolean hasRefreshToken(String email) {
-        String key = REFRESH_TOKEN_PREFIX + email;
+    public boolean hasRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
         Boolean exists = stringRedisTemplate.hasKey(key);
         return Boolean.TRUE.equals(exists);
     }
 
-    public boolean validateRefreshToken(String email, String refreshToken) {
-        String storedToken = getRefreshToken(email);
+    public boolean validateRefreshToken(Long userId, String refreshToken) {
+        String storedToken = getRefreshToken(userId);
         boolean isValid = storedToken != null && storedToken.equals(refreshToken);
 
         if (isValid) {
-            log.info("Refresh token validation successful for user: {}", email);
+            log.info("Refresh token validation successful for user: {}", userId);
         } else {
-            log.warn("Refresh token validation failed for user: {}", email);
+            log.warn("Refresh token validation failed for user: {}", userId);
         }
 
         return isValid;

--- a/src/main/java/com/archiservice/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/archiservice/common/security/CustomUserDetailsService.java
@@ -26,7 +26,20 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
 
         if (isRefreshTokenRequest()) {
-            if (!refreshTokenService.hasRefreshToken(email)) {
+            if (!refreshTokenService.hasRefreshToken(user.getUserId())) {
+                throw new UsernameNotFoundException("Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
+            }
+        }
+
+        return new CustomUser(user);
+    }
+    
+    public CustomUser loadUserByUserId(Long userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+
+        if (isRefreshTokenRequest()) {
+            if (!refreshTokenService.hasRefreshToken(userId)) {
                 throw new UsernameNotFoundException("Refresh Token이 만료되었습니다. 다시 로그인해주세요.");
             }
         }

--- a/src/main/java/com/archiservice/survey/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/com/archiservice/survey/service/impl/SurveyServiceImpl.java
@@ -82,7 +82,7 @@ public class SurveyServiceImpl implements SurveyService{
 		Map<String, Object> claims = new HashMap<>();
 		claims.put("userId", userId);
 		claims.put("tagCode", tagCode);
-		String tagCodeAccessToken = jwtUtil.generateCustomToken(claims, user.getEmail());
+		String tagCodeAccessToken = jwtUtil.generateCustomToken(claims, user.getUserId());
 		
 		session.removeAttribute("tagCodeSum");
 		return ApiResponse.success(tagCodeAccessToken);


### PR DESCRIPTION
# 목적
현재 `JWT` 내에는 아래 6가지 정보를 포함
1. `userEmail` : 사용자 이메일
2. `userId` : 사용자 고유ID
3. `tagCode` 사용자 성향정보
4. `ageCode` 사용자 나이정보
5. `생성시간` : 토큰 생성시간
6. `만료시간` : 토큰 만료시간

현재 `JWT` 에서 `userEmail` 을 삭제

# 이유
1. 멘토링 피드백 : `JWT` &rarr; 성능보단 **보안**이 우선
    - 로그인할 때 사용하는 `email` 이 `JWT` 에 들어가는 것은 다소 바람직하지 않음.

2. 용도 중복 : `userEmail` 과 `uesrId` 모두 사용자를 식별하는데 사용
    - `PK`이자 더 가벼운 `userId` 가 목적과 성능 면에서 바람직.

# fix
1. 로그인 후 `JWT` 발급 시 `userEmail` 삽입 &rarr; `userId` 삽입
2. `responseDto` 에서 사용하던 `userEmail` &rarr; `userId`
3. `JwtAuthenticationFilter`에서 `userEmail` 추출 후 검사 &rarr; `userId` 추출 후 검사

# 응답
### 변경 전
```
{
  "userId": 1
  "tagCode": 281480479768613,
  "ageCode": "004",
  "sub": "user1@test.com",
  "iat": 1750055388,
  "exp": 1750057188
}
```

### 변경 후
```
{
  "tagCode": 281480479768613,
  "ageCode": "004",
  "sub": "1",
  "iat": 1750055388,
  "exp": 1750057188
}
```
# 테스트
`surveyTest.html` 내에서 login api 호출 시 200 응답 확인, 토큰 발급 확인